### PR TITLE
Adding batch range deletion support: `rocksdb:batch_delete_range/3+4`

### DIFF
--- a/c_src/CMakeLists.txt
+++ b/c_src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5.0 FATAL_ERROR)
 
 project(ErlangRocksDBNIF)
 

--- a/c_src/erocksdb.cc
+++ b/c_src/erocksdb.cc
@@ -129,6 +129,8 @@ static ErlNifFunc nif_funcs[] =
         {"batch_delete", 3, erocksdb::DeleteBatch, ERL_NIF_REGULAR_BOUND},
         {"batch_single_delete", 2, erocksdb::SingleDeleteBatch, ERL_NIF_REGULAR_BOUND},
         {"batch_single_delete", 3, erocksdb::SingleDeleteBatch, ERL_NIF_REGULAR_BOUND},
+        {"batch_delete_range", 3, erocksdb::DeleteRangeBatch, ERL_NIF_REGULAR_BOUND},
+        {"batch_delete_range", 4, erocksdb::DeleteRangeBatch, ERL_NIF_REGULAR_BOUND},
         {"batch_clear", 1, erocksdb::ClearBatch, ERL_NIF_REGULAR_BOUND},
         {"batch_savepoint", 1, erocksdb::BatchSetSavePoint, ERL_NIF_REGULAR_BOUND},
         {"batch_rollback", 1, erocksdb::BatchRollbackToSavePoint, ERL_NIF_REGULAR_BOUND},
@@ -375,7 +377,6 @@ ERL_NIF_TERM ATOM_EXCLUSIVE_MANUAL_COMPACTION;
 ERL_NIF_TERM ATOM_CHANGE_LEVEL;
 ERL_NIF_TERM ATOM_TARGET_LEVEL;
 ERL_NIF_TERM ATOM_ALLOW_WRITE_STALL;
-
 
 // Related to CompactionOptionsFIFO
 ERL_NIF_TERM ATOM_COMPACTION_OPTIONS_FIFO;

--- a/c_src/erocksdb.h
+++ b/c_src/erocksdb.h
@@ -82,6 +82,7 @@ ERL_NIF_TERM PutBatch(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM MergeBatch(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM DeleteBatch(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM SingleDeleteBatch(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+ERL_NIF_TERM DeleteRangeBatch(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM ClearBatch(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM BatchSetSavePoint(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM BatchRollbackToSavePoint(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);

--- a/src/rocksdb.erl
+++ b/src/rocksdb.erl
@@ -151,6 +151,7 @@
          batch_merge/3, batch_merge/4,
          batch_delete/2, batch_delete/3,
          batch_single_delete/2, batch_single_delete/3,
+         batch_delete_range/3, batch_delete_range/4,
          batch_clear/1,
          batch_savepoint/1,
          batch_rollback/1,
@@ -271,7 +272,7 @@
 
 -type compaction_options_fifo() :: [{max_table_file_size, pos_integer()} |
                                     {allow_compaction, boolean()}].
-                            
+
 
 -type block_based_table_options() :: [{no_block_cache, boolean()} |
                                       {block_size, pos_integer()} |
@@ -1236,6 +1237,16 @@ batch_single_delete(_Batch, _Key) ->
 %% @doc like `batch_single_delete/2' but apply the operation to a column family
 -spec batch_single_delete(Batch :: batch_handle(), ColumnFamily :: cf_handle(), Key :: binary()) -> ok.
 batch_single_delete(_Batch, _ColumnFamily, _Key) ->
+  ?nif_stub.
+
+%% @doc batch implementation of `delete_range/5`
+-spec batch_delete_range(Batch :: batch_handle(), Begin :: binary(), End :: binary()) -> ok.
+batch_delete_range(_Batch, _Begin, _End) ->
+  ?nif_stub.
+
+%% @doc batch implementation of `delete_range/5, but apply the operation to a column family`
+-spec batch_delete_range(Batch :: batch_handle(), ColumnFamily :: cf_handle(), Begin :: binary(), End :: binary()) -> ok.
+batch_delete_range(_Batch, _ColumnFamily, _Begin, _End) ->
   ?nif_stub.
 
 %% @doc return the number of operations in the batch


### PR DESCRIPTION
Hey friends!

I've implemented the batch version of `DeleteRange` as `rocksdb:batch_delete_range/3+4`, with tests. 

Please let me know if there're any changes that'd make it more acceptable to merge.

Thanks for maintaining this library! <3