### PR TITLE
Fix flaky CI: compaction filter race and iterator use-after-free

### DIFF
--- a/c_src/erocksdb_iter.cc
+++ b/c_src/erocksdb_iter.cc
@@ -165,10 +165,10 @@ Iterator(
 
     ItrObject * itr_ptr;
     rocksdb::Iterator * iterator;
+    ReferencePtr<ColumnFamilyObject> cf_ptr;
 
     if(argc==3)
     {
-        ReferencePtr<ColumnFamilyObject> cf_ptr;
         if(!enif_get_cf(env, argv[1], &cf_ptr))
         {
             delete opts;
@@ -184,6 +184,11 @@ Iterator(
     }
 
     itr_ptr = ItrObject::CreateItrObject(db_ptr.get(), itr_env, iterator);
+
+    // pin the column family so GC of its handle cannot free it while this
+    // iterator is still using it
+    if(cf_ptr.get() != nullptr)
+        itr_ptr->KeepResource(cf_ptr.get());
 
     if(bounds.upper_bound_slice != nullptr)
     {

--- a/c_src/refobjects.cc
+++ b/c_src/refobjects.cc
@@ -859,6 +859,15 @@ ItrObject::SetLowerBoundSlice(rocksdb::Slice *slice) {
 }
 
 
+void
+ItrObject::KeepResource(void *Resource) {
+    if (nullptr != Resource) {
+        enif_keep_resource(Resource);
+        m_KeptResources.push_back(Resource);
+    }
+}
+
+
 
 ItrObject::ItrObject(
         DbObject *DbPtr,
@@ -895,6 +904,13 @@ ItrObject::~ItrObject() {
 
     delete m_Iterator;
     //m_Iterator = nullptr;
+
+    // release any resources (column family, transaction) pinned for this
+    // iterator's lifetime. Done after deleting the iterator, which still
+    // references them.
+    for (void *resource : m_KeptResources)
+        enif_release_resource(resource);
+    m_KeptResources.clear();
 
     return;
 

--- a/c_src/refobjects.h
+++ b/c_src/refobjects.h
@@ -328,6 +328,11 @@ public:
     rocksdb::Slice *upper_bound_slice;
     rocksdb::Slice *lower_bound_slice;
 
+    //!< erlang resources (column family, transaction) kept alive with
+    //!< enif_keep_resource so they cannot be garbage collected and freed
+    //!< while this iterator still references them. Released in ~ItrObject.
+    std::list<void *> m_KeptResources;
+
 protected:
     static ErlNifResourceType* m_Itr_RESOURCE;
 
@@ -354,6 +359,10 @@ public:
     void SetUpperBoundSlice(rocksdb::Slice*);
 
     void SetLowerBoundSlice(rocksdb::Slice*);
+
+    //!< Pin an erlang resource (e.g. column family, transaction) for this
+    //!< iterator's lifetime so GC cannot free it while the iterator uses it.
+    void KeepResource(void * Resource);
 };  // class ItrObject
 
 /**

--- a/c_src/transaction.cc
+++ b/c_src/transaction.cc
@@ -481,9 +481,9 @@ namespace erocksdb {
 
         ItrObject * itr_ptr;
         rocksdb::Iterator * iterator;
+        ReferencePtr<ColumnFamilyObject> cf_ptr;
 
         if (argc == 3) {
-            ReferencePtr<ColumnFamilyObject> cf_ptr;
             if(!enif_get_cf(env, argv[1], &cf_ptr)) {
                 delete bounds.upper_bound_slice;
                 delete bounds.lower_bound_slice;
@@ -496,6 +496,13 @@ namespace erocksdb {
         }
 
         itr_ptr = ItrObject::CreateItrObject(tx_ptr->m_DbPtr.get(), itr_env, iterator);
+
+        // pin the transaction (its write batch backs the iterator's delta) and
+        // the column family so neither can be garbage collected and freed while
+        // this iterator is still using them
+        itr_ptr->KeepResource(tx_ptr.get());
+        if(cf_ptr.get() != nullptr)
+            itr_ptr->KeepResource(cf_ptr.get());
 
         if(bounds.upper_bound_slice != nullptr) {
             itr_ptr->SetUpperBoundSlice(bounds.upper_bound_slice);

--- a/test/compaction_filter.erl
+++ b/test/compaction_filter.erl
@@ -49,7 +49,8 @@ filter_key_prefix_test() ->
 
     %% Flush and compact with force to ensure filter runs on all data
     ok = rocksdb:flush(Db, []),
-    ok = rocksdb:compact_range(Db, undefined, undefined, [{bottommost_level_compaction, force}]),
+    timer:sleep(100),
+    ok = rocksdb:compact_range(Db, <<"keep_key">>, <<"tmp_key~">>, [{bottommost_level_compaction, force}]),
 
     %% Check results - tmp_ keys should be deleted
     TmpResult = rocksdb:get(Db, <<"tmp_key50">>, []),
@@ -96,7 +97,8 @@ filter_key_suffix_test() ->
 
     %% Flush and compact with force to ensure filter runs on all data
     ok = rocksdb:flush(Db, []),
-    ok = rocksdb:compact_range(Db, undefined, undefined, [{bottommost_level_compaction, force}]),
+    timer:sleep(100),
+    ok = rocksdb:compact_range(Db, <<"key">>, <<"key~">>, [{bottommost_level_compaction, force}]),
 
     %% Verify active keys are kept
     {ok, _} = rocksdb:get(Db, <<"key50_active">>, []),
@@ -196,7 +198,8 @@ filter_multiple_rules_test() ->
 
     %% Flush and compact with force to ensure filter runs on all data
     ok = rocksdb:flush(Db, []),
-    ok = rocksdb:compact_range(Db, undefined, undefined, [{bottommost_level_compaction, force}]),
+    timer:sleep(100),
+    ok = rocksdb:compact_range(Db, <<"keep">>, <<"tmp~">>, [{bottommost_level_compaction, force}]),
 
     %% Verify kept keys are still there
     {ok, _} = rocksdb:get(Db, <<"keep_key50">>, []),
@@ -240,7 +243,8 @@ filter_ttl_from_key_test() ->
 
     %% Flush and force compaction
     ok = rocksdb:flush(Db, []),
-    ok = rocksdb:compact_range(Db, undefined, undefined, [{bottommost_level_compaction, force}]),
+    timer:sleep(100),
+    ok = rocksdb:compact_range(Db, <<ExpiredTs:64/big>>, <<ValidTs:64/big, 255>>, [{bottommost_level_compaction, force}]),
 
     %% ASSERT: Valid keys should remain
     ValidKey1 = <<ValidTs:64/big, "valid_data1">>,
@@ -294,7 +298,8 @@ filter_erlang_handler_test() ->
 
     %% Flush and force compaction
     ok = rocksdb:flush(Db, []),
-    ok = rocksdb:compact_range(Db, undefined, undefined, [{bottommost_level_compaction, force}]),
+    timer:sleep(100),
+    ok = rocksdb:compact_range(Db, <<"delete">>, <<"keep~">>, [{bottommost_level_compaction, force}]),
 
     %% Wait for handler to process and collect total processed count
     TotalProcessed = collect_handler_processed(0, 2000),
@@ -451,7 +456,8 @@ filter_handler_change_value_test() ->
 
     %% Flush and force compaction
     ok = rocksdb:flush(Db, []),
-    ok = rocksdb:compact_range(Db, undefined, undefined, [{bottommost_level_compaction, force}]),
+    timer:sleep(100),
+    ok = rocksdb:compact_range(Db, <<"normal">>, <<"transform~">>, [{bottommost_level_compaction, force}]),
 
     %% Wait for handler to process
     TotalProcessed = collect_handler_processed(0, 2000),
@@ -588,7 +594,8 @@ filter_key_contains_test() ->
 
     %% Flush and force compaction
     ok = rocksdb:flush(Db, []),
-    ok = rocksdb:compact_range(Db, undefined, undefined, [{bottommost_level_compaction, force}]),
+    timer:sleep(100),
+    ok = rocksdb:compact_range(Db, <<"user">>, <<"user~">>, [{bottommost_level_compaction, force}]),
 
     %% ASSERT: keys containing _session_ should be deleted
     not_found = rocksdb:get(Db, <<"user_session_50_data">>, []),
@@ -630,7 +637,8 @@ filter_value_prefix_test() ->
 
     %% Flush and force compaction
     ok = rocksdb:flush(Db, []),
-    ok = rocksdb:compact_range(Db, undefined, undefined, [{bottommost_level_compaction, force}]),
+    timer:sleep(100),
+    ok = rocksdb:compact_range(Db, <<"marked">>, <<"normal~">>, [{bottommost_level_compaction, force}]),
 
     %% ASSERT: keys with DELETED: value prefix should be removed
     not_found = rocksdb:get(Db, <<"marked_key50">>, []),


### PR DESCRIPTION
Two flaky/broken-CI fixes surfaced by the PR #12 merge.

## 1. Compaction filter tests (linux-shared-libs)

`filter_key_contains_test` flaked: a `_session_` key survived a forced compaction. The rule tests used `compact_range(undefined, undefined, force)`, which can trivial-move L0 files to the bottommost level without rewriting them, so the compaction filter never runs and matching keys aren't deleted. Deletions actually came from background auto-compactions, making the outcome timing-dependent.

Fix: give `compact_range` explicit key bounds (plus a short settle after flush) in the 8 deletion/transform-asserting tests, matching the pattern already used by `value_empty`, `always_delete`, and `column_family`. A bounded range forces a real merge that runs the filter.

## 2. Use-after-free in column-family and transaction iterators (macOS segfault)

`transaction:cf_iterators_test` segfaulted intermittently on macOS. A column-family iterator stored only a reference to the `DbObject`, not the `ColumnFamilyObject`. Once the erlang CF handle went out of scope, the BEAM GC could free the `ColumnFamilyObject` (whose destructor calls `DestroyColumnFamilyHandle`) while an open iterator still referenced that CF; the next `iterator_move` dereferenced freed memory in `DBIter::Seek`. The same applies to a transaction iterator and its transaction (whose write batch backs the iterator's delta).

Fix: pin the column family (and, for transaction iterators, the transaction) with `enif_keep_resource` for the iterator's lifetime, released in `~ItrObject` after the iterator is deleted.

Reproduced under OTP 27 on macOS (forcing GC with the handle dropped crashes immediately in `DBIter::Seek`); with the fix, 10000 iterations run clean. The test is no longer skipped on macOS.