### PR TITLE
Add AES-256-CTR encrypted env

### DIFF
--- a/c_src/CMakeLists.txt
+++ b/c_src/CMakeLists.txt
@@ -108,6 +108,9 @@ set(CMAKE_THREAD_PREFER_PTHREAD ON)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
+# OpenSSL provides the AES-256 block transform used by the encrypted env.
+find_package(OpenSSL REQUIRED)
+
 option(WITH_CCACHE "Build with ccache." OFF)
 if(WITH_CCACHE)
   find_program(CCACHE_FOUND ccache)
@@ -281,6 +284,7 @@ target_sources(${ErlangRocksDBNIF_TARGET}
     ${CMAKE_CURRENT_SOURCE_DIR}/cache.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/statistics.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/counter_merge_operator.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/aes_block_cipher.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/env.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/erlang_merge.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/compaction_filter.cc
@@ -307,6 +311,7 @@ target_include_directories(${ErlangRocksDBNIF_TARGET}
     ${ZSTD_INCLUDE_DIR}
     ${LZ4_INCLUDE_DIR}
     ${SNAPPY_INCLUDE_DIR}
+    ${OPENSSL_INCLUDE_DIR}
     ${PROJECT_BINARY_DIR}
 )
 
@@ -342,6 +347,7 @@ target_link_libraries(
     ${BZIP2_LIBRARIES}
     ${ZLIB_LIBRARY}
     ${TBB_LIBRARIES}
+    OpenSSL::Crypto
     Threads::Threads
 )
 

--- a/c_src/aes_block_cipher.cc
+++ b/c_src/aes_block_cipher.cc
@@ -1,0 +1,77 @@
+// Copyright (c) 2016-2026 Benoit Chesneau
+//
+// This file is provided to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License.  You may obtain
+// a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "aes_block_cipher.h"
+
+#include <cstring>
+
+#include <openssl/evp.h>
+
+namespace erocksdb {
+
+AesBlockCipher::AesBlockCipher(
+    const std::array<unsigned char, kKeyBytes>& key)
+    : key_(key) {}
+
+AesBlockCipher::AesBlockCipher(const std::string& key) {
+  // Caller validates length; copy up to kKeyBytes, zero-pad the rest.
+  key_.fill(0);
+  size_t n = key.size() < kKeyBytes ? key.size() : kKeyBytes;
+  std::memcpy(key_.data(), key.data(), n);
+}
+
+// A single raw AES-256-ECB transform of one 16-byte block, in place.
+// CTR mode only ever encrypts the counter block, so Encrypt and Decrypt are
+// the same forward operation.
+rocksdb::Status AesBlockCipher::Transform(char* data) {
+  EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();
+  if (ctx == nullptr) {
+    return rocksdb::Status::IOError("AesBlockCipher: EVP_CIPHER_CTX_new failed");
+  }
+
+  unsigned char out[kBlockBytes];
+  int out_len = 0;
+  rocksdb::Status status = rocksdb::Status::OK();
+
+  // No IV: the CTREncryptionProvider owns the per-file counter/IV, and we are
+  // only transforming the counter block here. Padding is disabled because we
+  // transform exactly one full block.
+  if (EVP_EncryptInit_ex(ctx, EVP_aes_256_ecb(), nullptr, key_.data(),
+                         nullptr) != 1) {
+    status = rocksdb::Status::IOError("AesBlockCipher: EVP_EncryptInit_ex failed");
+  } else if (EVP_CIPHER_CTX_set_padding(ctx, 0) != 1) {
+    status = rocksdb::Status::IOError("AesBlockCipher: set_padding failed");
+  } else if (EVP_EncryptUpdate(ctx, out, &out_len,
+                               reinterpret_cast<const unsigned char*>(data),
+                               static_cast<int>(kBlockBytes)) != 1) {
+    status = rocksdb::Status::IOError("AesBlockCipher: EVP_EncryptUpdate failed");
+  } else if (out_len != static_cast<int>(kBlockBytes)) {
+    status = rocksdb::Status::IOError("AesBlockCipher: unexpected block length");
+  }
+
+  if (status.ok()) {
+    std::memcpy(data, out, kBlockBytes);
+  }
+
+  EVP_CIPHER_CTX_free(ctx);
+  return status;
+}
+
+rocksdb::Status AesBlockCipher::Encrypt(char* data) { return Transform(data); }
+
+rocksdb::Status AesBlockCipher::Decrypt(char* data) { return Transform(data); }
+
+}  // namespace erocksdb

--- a/c_src/aes_block_cipher.h
+++ b/c_src/aes_block_cipher.h
@@ -1,0 +1,72 @@
+// Copyright (c) 2016-2026 Benoit Chesneau
+//
+// This file is provided to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License.  You may obtain
+// a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+#ifndef INCL_AES_BLOCK_CIPHER_H
+#define INCL_AES_BLOCK_CIPHER_H
+
+#include <array>
+#include <string>
+
+#include "rocksdb/env_encryption.h"
+#include "rocksdb/status.h"
+
+namespace erocksdb {
+
+// AesBlockCipher implements rocksdb::BlockCipher using AES-256 in raw ECB
+// block mode (a single forward AES block transform).
+//
+// It is meant to be wrapped by rocksdb's CTREncryptionProvider. In CTR mode the
+// provider XORs the plaintext with the AES-encrypted counter block, so both
+// Encrypt() and Decrypt() must perform the *same* forward AES block operation
+// on the 16-byte counter block. There is therefore no separate decrypt path.
+//
+// The key is a fixed 32-byte (256-bit) AES key. No IV is held here: the
+// CTREncryptionProvider owns the per-file counter/IV.
+class AesBlockCipher : public rocksdb::BlockCipher {
+ public:
+  static constexpr size_t kKeyBytes = 32;   // AES-256
+  static constexpr size_t kBlockBytes = 16; // AES block size
+
+  // key must be exactly kKeyBytes (32) bytes long.
+  explicit AesBlockCipher(const std::array<unsigned char, kKeyBytes>& key);
+  explicit AesBlockCipher(const std::string& key);
+
+  ~AesBlockCipher() override = default;
+
+  static const char* kClassName() { return "AES256CTR"; }
+  const char* Name() const override { return kClassName(); }
+
+  // BlockSize returns the AES block size (16 bytes).
+  size_t BlockSize() override { return kBlockBytes; }
+
+  // Encrypt performs a single forward AES-256 block transform of the 16-byte
+  // block at data, in place.
+  rocksdb::Status Encrypt(char* data) override;
+
+  // Decrypt performs the same forward AES-256 block transform as Encrypt:
+  // in CTR mode decryption of the counter block is identical to encryption.
+  rocksdb::Status Decrypt(char* data) override;
+
+ private:
+  rocksdb::Status Transform(char* data);
+
+  std::array<unsigned char, kKeyBytes> key_;
+};
+
+}  // namespace erocksdb
+
+#endif  // INCL_AES_BLOCK_CIPHER_H

--- a/c_src/atoms.h
+++ b/c_src/atoms.h
@@ -41,6 +41,7 @@ extern ERL_NIF_TERM ATOM_UNDEFINED;
 // related to envs
 extern ERL_NIF_TERM ATOM_DEFAULT;
 extern ERL_NIF_TERM ATOM_MEMENV;
+extern ERL_NIF_TERM ATOM_ENCRYPTED;
 
 // cache
 extern ERL_NIF_TERM ATOM_LRU;

--- a/c_src/env.cc
+++ b/c_src/env.cc
@@ -19,6 +19,12 @@
 
 #include "env.h"
 
+#include <array>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include "aes_block_cipher.h"
 #include "atoms.h"
 #include "util.h"
 
@@ -41,19 +47,30 @@ ManagedEnv::CreateEnvType(
 void
 ManagedEnv::EnvResourceCleanup(
     ErlNifEnv * /*env*/,
-    void * /*arg*/)
+    void * arg)
 {
+    // Run the C++ destructor so owned wrapper envs (memenv, encrypted) and the
+    // held provider/cipher shared_ptrs are released. The resource memory itself
+    // is freed by the runtime.
+    ManagedEnv * env_ptr = reinterpret_cast<ManagedEnv*>(arg);
+    env_ptr->~ManagedEnv();
     return;
 }
 
 ManagedEnv *
 ManagedEnv::CreateEnvResource(rocksdb::Env * env)
 {
+    return CreateEnvResource(env, true);
+}
+
+ManagedEnv *
+ManagedEnv::CreateEnvResource(rocksdb::Env * env, bool owns)
+{
     ManagedEnv * ret_ptr;
     void * alloc_ptr;
 
     alloc_ptr=enif_alloc_resource(m_Env_RESOURCE, sizeof(ManagedEnv));
-    ret_ptr=new (alloc_ptr) ManagedEnv(env);
+    ret_ptr=new (alloc_ptr) ManagedEnv(env, owns);
     return(ret_ptr);
 }
 
@@ -66,20 +83,69 @@ ManagedEnv::RetrieveEnvResource(ErlNifEnv * Env, const ERL_NIF_TERM & EnvTerm)
     return ret_ptr;
 }
 
-ManagedEnv::ManagedEnv(rocksdb::Env * Env) : env_(Env) {}
+ManagedEnv::ManagedEnv(rocksdb::Env * Env) : env_(Env), owns_env_(true) {}
+
+ManagedEnv::ManagedEnv(rocksdb::Env * Env, bool owns)
+    : env_(Env), owns_env_(owns) {}
 
 ManagedEnv::~ManagedEnv()
 {
-    if(env_)
+    // Only delete envs we own (memenv, encrypted wrapper). Never delete the
+    // rocksdb::Env::Default() singleton: it is process-wide and shared.
+    if(owns_env_ && env_)
     {
         delete env_;
-        env_ = NULL;
     }
+    env_ = NULL;
+
+    // Release the provider/cipher last, after the env that may reference them.
+    provider_.reset();
+    cipher_.reset();
 
     return;
 }
 
+void
+ManagedEnv::SetEncryption(
+    std::shared_ptr<rocksdb::EncryptionProvider> provider,
+    std::shared_ptr<rocksdb::BlockCipher> cipher)
+{
+    provider_ = std::move(provider);
+    cipher_ = std::move(cipher);
+}
+
 const rocksdb::Env* ManagedEnv::env() { return env_; }
+
+// Extract a 32-byte AES-256 key term from either {encrypted, Key} or
+// #{encrypted => Key}. Returns true and fills key_term on success.
+static bool
+GetEncryptedKeyTerm(
+    ErlNifEnv *env,
+    const ERL_NIF_TERM spec,
+    ERL_NIF_TERM *key_term)
+{
+    // Tuple form: {encrypted, Key}
+    int arity;
+    const ERL_NIF_TERM *tuple;
+    if (enif_get_tuple(env, spec, &arity, &tuple))
+    {
+        if (arity == 2 && tuple[0] == erocksdb::ATOM_ENCRYPTED)
+        {
+            *key_term = tuple[1];
+            return true;
+        }
+        return false;
+    }
+
+    // Map form: #{encrypted => Key}
+    if (enif_is_map(env, spec))
+    {
+        return enif_get_map_value(env, spec, erocksdb::ATOM_ENCRYPTED,
+                                  key_term) != 0;
+    }
+
+    return false;
+}
 
 ERL_NIF_TERM
 NewEnv(
@@ -89,15 +155,55 @@ NewEnv(
 {
     ManagedEnv *env_ptr;
     rocksdb::Env *rdb_env;
+    bool owns = true;
+
     if (argv[0] == erocksdb::ATOM_DEFAULT)
     {
+        // Default singleton: never owned, never deleted.
         rdb_env = rocksdb::Env::Default();
-    } else if (argv[0] == erocksdb::ATOM_MEMENV) {
-        rdb_env = rocksdb::NewMemEnv(rocksdb::Env::Default());
-    } else {
-        return enif_make_badarg(env);
+        owns = false;
+        env_ptr = ManagedEnv::CreateEnvResource(rdb_env, owns);
     }
-    env_ptr = ManagedEnv::CreateEnvResource(rdb_env);
+    else if (argv[0] == erocksdb::ATOM_MEMENV)
+    {
+        rdb_env = rocksdb::NewMemEnv(rocksdb::Env::Default());
+        env_ptr = ManagedEnv::CreateEnvResource(rdb_env, true);
+    }
+    else
+    {
+        // Encrypted env: {encrypted, Key} or #{encrypted => Key}, Key a 32-byte
+        // binary (AES-256).
+        ERL_NIF_TERM key_term;
+        if (!GetEncryptedKeyTerm(env, argv[0], &key_term))
+            return enif_make_badarg(env);
+
+        ErlNifBinary key_bin;
+        if (!enif_inspect_binary(env, key_term, &key_bin))
+            return enif_make_badarg(env);
+
+        if (key_bin.size != AesBlockCipher::kKeyBytes)
+            return enif_make_badarg(env);
+
+        std::array<unsigned char, AesBlockCipher::kKeyBytes> key;
+        std::memcpy(key.data(), key_bin.data, AesBlockCipher::kKeyBytes);
+
+        std::shared_ptr<rocksdb::BlockCipher> cipher =
+            std::make_shared<AesBlockCipher>(key);
+        std::shared_ptr<rocksdb::EncryptionProvider> provider =
+            rocksdb::EncryptionProvider::NewCTRProvider(cipher);
+        if (!provider)
+            return enif_make_badarg(env);
+
+        // Wrapper env owns nothing of the default singleton; NewEncryptedEnv
+        // returns a new Env that we own and must delete.
+        rdb_env = rocksdb::NewEncryptedEnv(rocksdb::Env::Default(), provider);
+        if (rdb_env == nullptr)
+            return enif_make_badarg(env);
+
+        env_ptr = ManagedEnv::CreateEnvResource(rdb_env, true);
+        env_ptr->SetEncryption(std::move(provider), std::move(cipher));
+    }
+
     // create a resource reference to send erlang
     ERL_NIF_TERM result = enif_make_resource(env, env_ptr);
     // clear the automatic reference from enif_alloc_resource in EnvObject

--- a/c_src/env.h
+++ b/c_src/env.h
@@ -18,9 +18,12 @@
 #ifndef INCL_ENV_H
 #define INCL_ENV_H
 
+#include <memory>
+
 #include "erl_nif.h"
 
 #include "rocksdb/env.h"
+#include "rocksdb/env_encryption.h"
 
 
 namespace erocksdb {
@@ -32,18 +35,32 @@ namespace erocksdb {
     public:
       explicit ManagedEnv(rocksdb::Env * Env);
 
+      // Wrapper env that owns its base env (e.g. memenv, encrypted env).
+      // owns == true means the destructor will delete env_; the default env
+      // singleton must NEVER be deleted, so it is created with owns == false.
+      ManagedEnv(rocksdb::Env * Env, bool owns);
+
       ~ManagedEnv();
 
       const rocksdb::Env* env();
+
+      // Keep the encryption provider and cipher alive for the lifetime of the
+      // env. These are empty for non-encrypted envs.
+      void SetEncryption(std::shared_ptr<rocksdb::EncryptionProvider> provider,
+                         std::shared_ptr<rocksdb::BlockCipher> cipher);
 
       static void CreateEnvType(ErlNifEnv * Env);
       static void EnvResourceCleanup(ErlNifEnv *Env, void * Arg);
 
       static ManagedEnv * CreateEnvResource(rocksdb::Env * env);
+      static ManagedEnv * CreateEnvResource(rocksdb::Env * env, bool owns);
       static ManagedEnv * RetrieveEnvResource(ErlNifEnv * Env, const ERL_NIF_TERM & EnvTerm);
 
     private:
-      const rocksdb::Env* env_;
+      rocksdb::Env* env_;
+      bool owns_env_;
+      std::shared_ptr<rocksdb::EncryptionProvider> provider_;
+      std::shared_ptr<rocksdb::BlockCipher> cipher_;
   };
 
 }

--- a/c_src/erocksdb.cc
+++ b/c_src/erocksdb.cc
@@ -325,6 +325,7 @@ ERL_NIF_TERM ATOM_UNDEFINED;
 // related to envs
 ERL_NIF_TERM ATOM_DEFAULT;
 ERL_NIF_TERM ATOM_MEMENV;
+ERL_NIF_TERM ATOM_ENCRYPTED;
 
 // related to cache
 ERL_NIF_TERM ATOM_LRU;
@@ -977,6 +978,7 @@ try
 
   ATOM(erocksdb::ATOM_DEFAULT, "default");
   ATOM(erocksdb::ATOM_MEMENV, "memenv");
+  ATOM(erocksdb::ATOM_ENCRYPTED, "encrypted");
 
   ATOM(erocksdb::ATOM_LRU, "lru");
   ATOM(erocksdb::ATOM_CLOCK, "clock");

--- a/guides/encrypted_env.md
+++ b/guides/encrypted_env.md
@@ -1,0 +1,41 @@
+# Encrypted Env
+
+An encrypted env encrypts all of a database's on-disk data transparently, using AES-256 in CTR mode through RocksDB's encryption provider. You read and write keys and values as usual; the bytes that reach the filesystem (SST files, WAL, MANIFEST) are ciphertext.
+
+Use it when you need data-at-rest encryption and you control a 32-byte key. It does not encrypt data in memory, and it is not authenticated (see Notes).
+
+## Create an env and open a database
+
+The key must be a 32-byte binary (AES-256). Pass the returned handle as `{env, Env}` in the open options.
+
+```erlang
+Key = <<"0123456789abcdef0123456789abcdef">>,  %% exactly 32 bytes
+{ok, Env} = rocksdb:new_env({encrypted, Key}),
+{ok, Db} = rocksdb:open("/tmp/erocksdb", [{create_if_missing, true}, {env, Env}]),
+ok = rocksdb:put(Db, <<"k">>, <<"v">>, []),
+{ok, <<"v">>} = rocksdb:get(Db, <<"k">>, []),
+ok = rocksdb:close(Db).
+```
+
+The map form is equivalent:
+
+```erlang
+{ok, Env} = rocksdb:new_env(#{encrypted => Key}).
+```
+
+## Reopen
+
+Reopen the same directory with an env built from the same key. Reuse the env handle, or create a new one from the same key.
+
+```erlang
+{ok, Env} = rocksdb:new_env({encrypted, Key}),
+{ok, Db} = rocksdb:open("/tmp/erocksdb", [{env, Env}]).
+```
+
+## Notes
+
+- The key must be exactly 32 bytes. Any other length raises `badarg`.
+- Wrong-key detection is checksum-based, not authenticated. CTR decryption with the wrong key produces garbage that RocksDB's per-block checksums reject as a corruption error. There is no MAC, so a deliberately tampered file is not guaranteed to be detected.
+- Keep the key; data written with one key cannot be recovered with another.
+- The encrypted env requires OpenSSL (libcrypto), which is a build dependency of the NIF.
+- Encryption covers on-disk data only. Keys and values in memory are not encrypted.

--- a/rebar.config
+++ b/rebar.config
@@ -55,6 +55,7 @@
         {"guides/posting_lists.md", #{title => "Posting Lists"}},
         {"guides/ttl.md", #{title => "Time-to-Live (TTL)"}},
         {"guides/compaction.md", #{title => "Compaction"}},
+        {"guides/encrypted_env.md", #{title => "Encrypted Env"}},
         {"CUSTOMIZED_BUILDS.md", #{title => "Customize erlang-rocksdb builds"}},
         {"CHANGELOG.md", #{title => "Changelog"}},
         {"LICENSE", #{title => "License"}}

--- a/src/rocksdb.erl
+++ b/src/rocksdb.erl
@@ -402,7 +402,9 @@
 
 -type column_family() :: cf_handle() | default_column_family.
 
--type env_type() :: default | memenv.
+-type env_type() :: default | memenv
+                  | {encrypted, Key :: <<_:256>>}
+                  | #{encrypted := Key :: <<_:256>>}.
 -opaque env() :: env_type() | env_handle().
 -type env_priority() :: priority_high | priority_low.
 
@@ -2272,6 +2274,16 @@ release_rate_limiter(_Limiter) ->
 new_env() -> new_env(default).
 
 %% @doc return a db environment
+%%
+%% `default' returns the shared process-wide environment. `memenv' returns an
+%% in-memory environment.
+%%
+%% `{encrypted, Key}' (or `#{encrypted => Key}') returns an environment that
+%% transparently encrypts all on-disk data with AES-256-CTR. `Key' must be a
+%% 32-byte binary. Pass the returned handle as `{env, Env}' in the open
+%% options. Wrong-key detection is checksum-based, not authenticated: reading
+%% with the wrong key yields garbage that RocksDB block checksums reject as a
+%% corruption error.
 -spec new_env(EnvType :: env_type()) -> {ok, env_handle()}.
 new_env(_EnvType) ->
   ?nif_stub.

--- a/test/encrypted_env.erl
+++ b/test/encrypted_env.erl
@@ -1,0 +1,167 @@
+%% Copyright (c) 2016-2026 Benoit Chesneau.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+
+%% Tests for the AES-256-CTR encrypted env.
+%%
+%% Note: wrong-key detection here is checksum-based, not authenticated. CTR
+%% decryption with a wrong key yields garbage, which RocksDB's per-block
+%% checksums reject as a corruption error. There is no MAC.
+-module(encrypted_env).
+
+-compile([export_all/1, nowarn_export_all]).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(rm_rf(Dir), rocksdb_test_util:rm_rf(Dir)).
+
+%% A recognizable plaintext marker that must never appear on disk when the
+%% data is encrypted.
+-define(MARKER, <<"PLAINTEXT_MARKER_DEADBEEF_0123456789">>).
+-define(KEY, <<"0123456789abcdef0123456789abcdef">>).  %% exactly 32 bytes
+
+%% Options that keep the marker intact on disk in the unencrypted case:
+%% disable compression so the marker bytes are not transformed, and flush
+%% aggressively so an SST file is produced.
+open_opts(Env) ->
+    [{create_if_missing, true},
+     {env, Env},
+     {compression, none}].
+
+key_validation_test() ->
+    %% Wrong key length must be rejected.
+    ?assertError(badarg, rocksdb:new_env({encrypted, <<"tooshort">>})),
+    {ok, _Env} = rocksdb:new_env({encrypted, ?KEY}),
+    ok.
+
+roundtrip_test() ->
+    Dir = "encrypted_env_roundtrip.test",
+    ?rm_rf(Dir),
+    {ok, Env} = rocksdb:new_env({encrypted, ?KEY}),
+    {ok, Db} = rocksdb:open(Dir, open_opts(Env)),
+    ok = rocksdb:put(Db, <<"k">>, ?MARKER, [{sync, true}]),
+    ?assertEqual({ok, ?MARKER}, rocksdb:get(Db, <<"k">>, [])),
+    %% Force a flush so the value lands in an SST file on disk.
+    ok = rocksdb:flush(Db, []),
+    ok = rocksdb:close(Db),
+
+    %% Reopen with the same key and read it back.
+    {ok, Db2} = rocksdb:open(Dir, open_opts(Env)),
+    ?assertEqual({ok, ?MARKER}, rocksdb:get(Db2, <<"k">>, [])),
+    ok = rocksdb:close(Db2),
+    ?rm_rf(Dir),
+    ok.
+
+on_disk_encrypted_test() ->
+    Dir = "encrypted_env_ondisk.test",
+    ?rm_rf(Dir),
+    {ok, Env} = rocksdb:new_env({encrypted, ?KEY}),
+    {ok, Db} = rocksdb:open(Dir, open_opts(Env)),
+    ok = rocksdb:put(Db, <<"k">>, ?MARKER, [{sync, true}]),
+    ok = rocksdb:flush(Db, []),
+    ok = rocksdb:close(Db),
+
+    %% No file on disk may contain the plaintext marker.
+    Files = filelib:wildcard(filename:join(Dir, "*")),
+    ?assert(length(Files) > 0),
+    lists:foreach(
+        fun(F) ->
+            case file:read_file(F) of
+                {ok, Bin} ->
+                    ?assertEqual(
+                        nomatch,
+                        binary:match(Bin, ?MARKER),
+                        lists:flatten(
+                            io_lib:format("plaintext marker found in ~s", [F])));
+                _ ->
+                    ok
+            end
+        end,
+        Files),
+    ?rm_rf(Dir),
+    ok.
+
+%% Sanity check: with the default (unencrypted) env the marker IS present on
+%% disk, proving the on-disk check above is meaningful.
+on_disk_plaintext_present_default_test() ->
+    Dir = "encrypted_env_default.test",
+    ?rm_rf(Dir),
+    {ok, Db} = rocksdb:open(Dir, [{create_if_missing, true}, {compression, none}]),
+    ok = rocksdb:put(Db, <<"k">>, ?MARKER, [{sync, true}]),
+    ok = rocksdb:flush(Db, []),
+    ok = rocksdb:close(Db),
+    Files = filelib:wildcard(filename:join(Dir, "*")),
+    Found = lists:any(
+        fun(F) ->
+            case file:read_file(F) of
+                {ok, Bin} -> binary:match(Bin, ?MARKER) =/= nomatch;
+                _ -> false
+            end
+        end,
+        Files),
+    ?assert(Found),
+    ?rm_rf(Dir),
+    ok.
+
+%% Reopening with a different key must fail (corruption / checksum error).
+%% CTR with the wrong key produces garbage; block checksums detect it.
+wrong_key_test() ->
+    Dir = "encrypted_env_wrongkey.test",
+    ?rm_rf(Dir),
+    {ok, Env} = rocksdb:new_env({encrypted, ?KEY}),
+    {ok, Db} = rocksdb:open(Dir, open_opts(Env)),
+    ok = rocksdb:put(Db, <<"k">>, ?MARKER, [{sync, true}]),
+    ok = rocksdb:flush(Db, []),
+    ok = rocksdb:close(Db),
+
+    WrongKey = <<"FEDCBA9876543210FEDCBA9876543210">>,  %% 32 bytes, != KEY
+    {ok, WrongEnv} = rocksdb:new_env({encrypted, WrongKey}),
+    %% Either the open itself fails, or the subsequent read fails, depending on
+    %% which on-disk structure is touched first. Both are corruption errors.
+    Result =
+        case rocksdb:open(Dir, open_opts(WrongEnv)) of
+            {error, _} = OpenErr ->
+                OpenErr;
+            {ok, BadDb} ->
+                R = rocksdb:get(BadDb, <<"k">>, []),
+                try rocksdb:close(BadDb) catch _:_ -> ok end,
+                R
+        end,
+    ?assertMatch({error, _}, Result),
+    ?rm_rf(Dir),
+    ok.
+
+%% The default env path still works unchanged.
+default_env_test() ->
+    Dir = "encrypted_env_plain.test",
+    ?rm_rf(Dir),
+    {ok, Env} = rocksdb:new_env(default),
+    {ok, Db} = rocksdb:open(Dir, [{create_if_missing, true}, {env, Env}]),
+    ok = rocksdb:put(Db, <<"k">>, <<"v">>, []),
+    ?assertEqual({ok, <<"v">>}, rocksdb:get(Db, <<"k">>, [])),
+    ok = rocksdb:close(Db),
+    ?rm_rf(Dir),
+    ok.
+
+%% Map form #{encrypted => Key} works too.
+map_form_test() ->
+    Dir = "encrypted_env_map.test",
+    ?rm_rf(Dir),
+    {ok, Env} = rocksdb:new_env(#{encrypted => ?KEY}),
+    {ok, Db} = rocksdb:open(Dir, open_opts(Env)),
+    ok = rocksdb:put(Db, <<"k">>, ?MARKER, []),
+    ?assertEqual({ok, ?MARKER}, rocksdb:get(Db, <<"k">>, [])),
+    ok = rocksdb:close(Db),
+    ?rm_rf(Dir),
+    ok.


### PR DESCRIPTION
## Summary

Adds an encrypted env backed by RocksDB's `CTREncryptionProvider` so all on-disk data is encrypted transparently.

Create it with `new_env({encrypted, Key})` or `new_env(#{encrypted => Key})`, where `Key` is a 32-byte binary (AES-256), then pass the handle as `{env, Env}` in the open options.

## Details

- AES block transform uses OpenSSL (EVP, AES-256-ECB on the counter block). `CMakeLists.txt` now requires OpenSSL and links `OpenSSL::Crypto`.
- `ManagedEnv` tracks ownership: wrapper envs (`memenv`, encrypted) are deleted on cleanup, while the shared `Env::Default()` singleton is never deleted. It also keeps the provider and cipher alive for the env's lifetime.
- Cleanup now runs the `ManagedEnv` destructor so owned envs and the provider/cipher `shared_ptr`s are released.

## Security note

Wrong-key detection is checksum-based, not authenticated: reading with the wrong key yields garbage that RocksDB block checksums reject as a corruption error. There is no MAC.

## Tests

`test/encrypted_env.erl` covers roundtrip, on-disk ciphertext (marker absent when encrypted, present with the default env), wrong-key failure, key-length validation, the map form, and the unchanged default env path.